### PR TITLE
New material library support & CLI args

### DIFF
--- a/Scripts/find_material_from_xml_dump.py
+++ b/Scripts/find_material_from_xml_dump.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import xml.etree.ElementTree as ET
+import argparse
 
 def find_material(file_text, parameters_to_find):
     root = ET.fromstring(file_text)
@@ -8,21 +9,35 @@ def find_material(file_text, parameters_to_find):
         # Find the name and label for materials including all the desired parameters.
         parameter_names = [node.attrib['name'] for node in material_node]
         if all(p in parameter_names for p in parameters_to_find):
-            return (material_node.attrib['name'], material_node.attrib['label'])
+            name = None
+            if 'name' in material_node.attrib:
+                name = material_node.attrib['name']
+            elif 'shaderLabel' in material_node.attrib:
+                name = material_node.attrib['shaderLabel']
+            else:
+                raise Exception("Material element has no 'name' or 'shaderLabel' attribute")
+                
+            label = None
+            if 'label' in material_node.attrib:
+                label = material_node.attrib['label']
+            elif 'materialLabel' in material_node.attrib:
+                label = material_node.attrib['materialLabel']
+            else:
+                raise Exception("Material element has no 'label' or 'materialLabel' attribute")
+            
+            yield (name, label)
 
     return None
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print(f'Usage: {sys.argv[0]} <xml material dump folder>')
-        exit(1)
+    parser = argparse.ArgumentParser(description='print materials with specified parameters')
+    parser.add_argument('--dir', type=str, help='the directory in which to look for xml files', required=True)
+    parser.add_argument('--params', nargs="+", help="space separated list of the parameters that should be included. if not specified, all materials will be printed.", default=[])
+    parser.add_argument('--first', action='store_true', help="only print the first material in the file", default=False, required=False)
+    args = parser.parse_args()
 
-    source_folder = os.path.abspath(sys.argv[1])
-
-    # Change this to whatever parameters should be included. 
-    # Setting this to an empty list will print all materials.
-    parameters_to_find = ['Texture4', 'Texture5', 'CustomVector3', 'CustomVector8']
+    source_folder = os.path.abspath(args.dir)
 
     # Parse all the xml files in the provided folder.
     for root, directories, file_paths in os.walk(source_folder):
@@ -31,6 +46,13 @@ if __name__ == '__main__':
                 abs_path = os.path.join(root, path)
                 with open(abs_path, 'r') as file:
                     data = file.read().encode('utf-16-be')
-                    material = find_material(data, parameters_to_find)
-                    if material is not None:
-                        print(material, path)
+                    try:
+                        materials = find_material(data, args.params)
+                        if materials is not None:
+                            for m in materials:
+                                print(m, path)
+                                if args.first:
+                                    break
+                        
+                    except Exception as e:
+                        print(f"Failed to parse XML file {abs_path}: {e}")


### PR DESCRIPTION
- Adds support for new material library XML exports using different attributes for material name and labels.
- Adds commandline options for input, the parameters to look for, and whether to only print the first or all of the results.